### PR TITLE
Convert the script into a runnable python package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,166 @@
 images/
 result/
 *.pdf
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@ This program converts pdf like this:
 To this:
 ![pdf with one slide for page](./readme_img/2022-10-20-162345_1857x989_scrot.png)
 
+## Installation
+
+With the project cloned in a local directory:
+```sh
+pip install .  
+```
+
 ## Usage
 
-`python3 main.py file1.pdf [file2.pdf ...] [-q N]`
+`pdf-cutter file1.pdf [file2.pdf ...] [-q N]`
 
 This program allows you to convert more than one pdf file at execution. The
 result pdfs are stored on the folder `result/` with the same name than the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pdf-cutter"
+dynamic = ["version"]
+dependencies = [
+  "pdf2image == 1.16.0",
+  "img2pdf == 0.4.4"
+]
+authors = [
+  {name = "Raul Gilabert", email = "raulgilabert@proton.me"}
+]
+description = "PDF file cutter for slides where 2 pages are in one of the file"
+readme = "README.md"
+license = {file = "LICENSE"}
+
+[project.scripts]
+pdf-cutter = "pdf_cutter.pdf_cutter:main"
+
+[tool.setuptools_scm]

--- a/src/pdf_cutter/__init__.py
+++ b/src/pdf_cutter/__init__.py
@@ -1,0 +1,3 @@
+__all__ = [
+    'pdf_cutter'
+]

--- a/src/pdf_cutter/__main__.py
+++ b/src/pdf_cutter/__main__.py
@@ -1,0 +1,3 @@
+if __name__ == "__main__":
+    from .pdf_cutter import main
+    main()

--- a/src/pdf_cutter/pdf_cutter.py
+++ b/src/pdf_cutter/pdf_cutter.py
@@ -3,6 +3,15 @@ import img2pdf
 import os
 import argparse
 
+try:
+    from importlib.metadata import version, metadata
+    __version__ = version("pdf-cutter")
+    __description__ = metadata("pdf-cutter")["Summary"]
+except:
+    __version__ = "UNKNOWN"
+    __description__ = "UNKNOWN"
+
+
 def detect_borders(image):
     width, _ = image.size
     # left, right, top, bottom
@@ -100,8 +109,7 @@ def convert_file(filename, quality):
     print("Ended with file: " + filename)
     print("------------------------")
 
-
-if __name__ == "__main__":
+def main():
     if os.path.exists("images"):
         os.system("rm -rf images")
 
@@ -110,9 +118,11 @@ if __name__ == "__main__":
 
     os.mkdir("images")
 
-    parser = argparse.ArgumentParser(prog='pdf_cutter', usage='%(prog)s [options] file1.pdf [file2.pdf ...]',
-                                            description='Crops wrong exported pdf slides into one page each')
+    parser = argparse.ArgumentParser(
+        description=__description__
+    )
 
+    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}')
     parser.add_argument('Files', metavar='files', nargs='+', type=str, 
                         help='the names of the files you want to fix')
     parser.add_argument('-q', '--quality', type=int,  choices=range(1,4),
@@ -126,4 +136,3 @@ if __name__ == "__main__":
         convert_file(file, quality)
 
     os.system("rm -rf images/")
-


### PR DESCRIPTION
More specifically:
- Use a full package layout instead of a single script file
- Configure `pyproject.toml` for package building with `setuptools`
- Autogenerate the version number from git tag + commit
- Allow the package to be invoked with `python -m pdf-cutter`
- Allow the package to be invoked with `pdf-cutter`
- Improve `argparse` code to show version and description from package
- Document the changes in the README
